### PR TITLE
build: Add a shap package.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ japanize-matplotlib = "^1.1.3"
 ipykernel = "^6.25.1"
 libcst = "^1.0.1"
 tqdm = "^4.66.1"
+shap = "^0.43.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.4.0"


### PR DESCRIPTION
@kimusaku 
@AkiraUra 

The change from 0.4.10 to 0.5.0 requires the shap package but does not install it.
Modify pyproject.toml to install the shap package.

Please take a review on it.