### PR TITLE
feat(Label_Ecoder):Support of Label Encoder in Multi Target Task

### DIFF
--- a/sapientml_core/templates/model_templates/model.py.jinja
+++ b/sapientml_core/templates/model_templates/model.py.jinja
@@ -22,21 +22,34 @@ model = {{ model_name }}({{ silent }}random_state=random_state_model, {{ params 
 from sklearn.multioutput import MultiOutputRegressor
 
 model = MultiOutputRegressor(model)
+
 {% elif is_multioutput_classification %}
 from sklearn.multioutput import MultiOutputClassifier
 
 model = MultiOutputClassifier(model)
 {% endif %}
 {% set xgbclassifier = "XGBClassifier" %}
-{% if model_name == xgbclassifier %}
+{% if pipeline.task.target_columns|length == 1 %}
+
 from sklearn.preprocessing import LabelEncoder
 
-label_encoder = LabelEncoder()
-target_train = pd.DataFrame(label_encoder.fit_transform(target_train), columns=TARGET_COLUMNS)
-{% endif %}
-{% if pipeline.task.target_columns|length == 1 %}
+if target_train.select_dtypes(include=['object']).columns.any():
+        str_columns = target_train.select_dtypes(include=['object']).columns
+        label_encoder= LabelEncoder()
+        for col in str_columns:
+                target_train[col] = label_encoder.fit_transform(target_train[col])
+                target_test[col] = label_encoder.transform(target_test[col])
+
 model.fit(feature_train, target_train.values.ravel())
 {% else %}
+
+from sklearn.preprocessing import LabelEncoder
+if target_train.select_dtypes(include=['object']).columns.any():
+        str_columns = target_train.select_dtypes(include=['object']).columns
+        label_encoder= LabelEncoder()
+        for col in str_columns:
+                target_train[col] = label_encoder.fit_transform(target_train[col])
+                target_test[col] = label_encoder.transform(target_test[col])
 model.fit(feature_train, target_train)
 {% endif %}
 y_pred = model.predict(feature_test)

--- a/sapientml_core/templates/model_templates/model_train.py.jinja
+++ b/sapientml_core/templates/model_templates/model_train.py.jinja
@@ -17,24 +17,46 @@ model = {{ model_name }}(random_state=random_state_model, {{ params }})
 from sklearn.multioutput import MultiOutputRegressor
 
 model = MultiOutputRegressor(model)
+
 {% elif is_multioutput_classification %}
 from sklearn.multioutput import MultiOutputClassifier
 
 model = MultiOutputClassifier(model)
 {% endif %}
+
 {% set xgbclassifier = "XGBClassifier" %}
-{% if model_name == xgbclassifier %}
-from sklearn.preprocessing import LabelEncoder
 
-label_encoder = LabelEncoder()
-target_train = pd.DataFrame(label_encoder.fit_transform(target_train), columns=TARGET_COLUMNS)
-with open('target_LabelEncoder.pkl', 'wb') as f:
-    pickle.dump(label_encoder, f)
-
-{% endif %}
 {% if pipeline.task.target_columns|length == 1 %}
+from sklearn.preprocessing import LabelEncoder
+flag=0
+if target_train.select_dtypes(include=['object']).columns.any():
+   str_columns = target_train.select_dtypes(include=['object']).columns
+   label_encoder= LabelEncoder()
+   flag=1
+   for col in str_columns:
+       target_train[col] = label_encoder.fit_transform(target_train[col])
+
+if flag==1:
+    with open('target_LabelEncoder.pkl', 'wb') as f:
+        pickle.dump(label_encoder, f)
+    flag=0
+
 model.fit(feature_train, target_train.values.ravel())
 {% else %}
+from sklearn.preprocessing import LabelEncoder
+flag=0
+if target_train.select_dtypes(include=['object']).columns.any():
+   str_columns = target_train.select_dtypes(include=['object']).columns
+   label_encoder= LabelEncoder()
+   flag=1
+   for col in str_columns:
+       target_train[col] = label_encoder.fit_transform(target_train[col])
+
+if flag==1:
+    with open('target_LabelEncoder.pkl', 'wb') as f:
+        pickle.dump(label_encoder, f)
+    flag=0
+
 model.fit(feature_train, target_train)
 {% endif %}
 with open('model.pkl', 'wb') as f:

--- a/sapientml_core/templates/other_templates/evaluation.py.jinja
+++ b/sapientml_core/templates/other_templates/evaluation.py.jinja
@@ -22,11 +22,24 @@ for i, col in enumerate(target_test.columns):
     one_acc = accuracy_score(target_test[col], y_pred[:, i:i+1])
     __accs.append(one_acc)
 print(f"RESULT: Accuracy : {str(sum(__accs)/len(__accs))}")
-{% elif pipeline.adaptation_metric == macros.Metric.F1.value %}
+
+{% elif (pipeline.adaptation_metric == macros.Metric.F1.value) and (not pipeline.is_multi_class_multi_targets) %}
 from sklearn import metrics
 
 f1 = metrics.f1_score(target_test, y_pred, average='macro')
 print('RESULT: F1 Score: ' + str(f1))
+
+{% elif pipeline.adaptation_metric == macros.Metric.F1.value and (pipeline.is_multi_class_multi_targets)%}
+from sklearn import metrics
+f1_scores = []
+
+for i, col in enumerate(target_test.columns):
+    one_f1 = metrics.f1_score(target_test[col], y_pred[:, i:i+1], average='macro')
+    f1_scores.append(one_f1)
+
+average_f1 = sum(f1_scores) / len(f1_scores)
+print(f"RESULT: Average F1 score: {average_f1}")
+
 {% elif pipeline.adaptation_metric == macros.Metric.R2.value %}
 from sklearn import metrics
 


### PR DESCRIPTION
**Description:** Tried to implement Label Encoder for categorical features in a Multi-target Classification/Regression Scenario. (This is an ongoing issue)

**Changes Made:** There are 3 files that were edited
1. model.py.jinja and model_train.py.jinja
2. evaluation.py.jinja

**In the first case,** I have added the logic where whenever a catgorical object is found in the features, we implement the Label Encoder thus ensuring all the categorical features are encoded. This solution proposed works for the multi-target scenario. But fails in the scenario where XGB Classifier is used. 

I have created a test experiment script as below

```
from sapientml import SapientML
import pandas as pd
from sklearn.metrics import f1_score
from sklearn.model_selection import train_test_split

cls = SapientML(
        target_columns=["sex","survived","pclass"],#,"pclass","sibsp"],
                task_type=None,  # suggested automatically from the target columns
               # adaptation_metric='auc'
                )

train_data = pd.read_csv("https://github.com/sapientml/sapientml/files/12481088/titanic.csv")
train_data, test_data = train_test_split(train_data)
y_true = test_data[["sex","survived","pclass"]].reset_index(drop=True)
test_data.drop(["sex","survived","pclass"], axis=1, inplace=True)
cls.fit(train_data, output_dir="./outputs")
y_pred = cls.predict(test_data)

```

Upon running this I get the below error
`ValueError: Invalid classes inferred from unique values of `y`.  Expected: [0 1 2], got [1 2 3]`

The above error is specific to XGBClassifier. Upon further investigation I found that Label Encoder does not works well with the latest version of XGBClassifier hence the issue. In this case the solution would be to use other encoding types like One Hot Encoder in the scenario where we have our selected model as XGBClassifier

Below is the reference link of the version issue:
https://stackoverflow.com/questions/71996617/invalid-classes-inferred-from-unique-values-of-y-expected-0-1-2-3-4-5-got

**In the second case,** when the evaluation metric is not mentioned, sapientML considers the F1 score by default as the metric. To support multi target, there was a need to change the F1 score metric evaluation. I used a for loop to go throw individual target columns and calculate it's F1 score. In this way I was able to solve the evaluation metric error.

Further discussion and course of action needs to be evaluated


