### PR TITLE
Fix AttributeError in __is_bool Method for Non-String Data

### DIFF
--- a/sapientml_core/explain/AutoEDA.py
+++ b/sapientml_core/explain/AutoEDA.py
@@ -292,6 +292,9 @@ class EDA(Dataset):
         if len(unique_vals) != 2:
             # total number of elements sould be two, to be considered
             return None
+        # Check if all elements in unique_vals are strings
+        if not all(isinstance(_, str) for _ in unique_vals):
+            return None  
         sorted_unique_vals = sorted([_.lower().strip() for _ in unique_vals])
         candidates = [
             # TODO: add dynamic values


### PR DESCRIPTION
This PR addresses an issue in the __is_bool method within the EDA component. Previously, the method attempted to call .lower() and .strip() on all elements of the unique_vals array without checking their data types. This behavior caused an AttributeError when the array contained non-string data types, such as floats. The error is illustrated below:
  
```
sorted_unique_vals = sorted([_.lower().strip() for _ in unique_vals])
                                 ^^^^^^^
AttributeError: 'float' object has no attribute 'lower'
```
  
**Modifications:**
- Added a check to ensure that all elements in unique_vals are strings before proceeding with the .lower() and .strip() operations.
- This change prevents the AttributeError by skipping the lowercasing and stripping process for non-string elements, thus ensuring that the method can handle arrays with mixed data types gracefully.

  
**Impact:**
- The fix enhances the robustness of the __is_bool function by allowing it to handle a wider range of input types without failing.
- It ensures that the method behaves as expected even when encountering data types other than strings, thereby improving the overall data processing reliability in the EDA component.
