### PR TITLE
fix: Handle infinity and large values in input to avoid ValueError with log1p

### DIFF
--- a/sapientml_core/templates/preprocessing_templates/log.py.jinja
+++ b/sapientml_core/templates/preprocessing_templates/log.py.jinja
@@ -1,7 +1,9 @@
 import numpy as np
 
 NUMERIC_COLS_TO_SCALE = {{ columns }}
-{{ train_dataset }}[NUMERIC_COLS_TO_SCALE] = np.log1p({{ train_dataset }}[NUMERIC_COLS_TO_SCALE])
+{{ train_dataset }}[NUMERIC_COLS_TO_SCALE] = np.log1p({{ train_dataset }}[NUMERIC_COLS_TO_SCALE]).replace([np.inf, -np.inf], np.nan).fillna({{ train_dataset }}[NUMERIC_COLS_TO_SCALE].mean())
+
 
 NUMERIC_COLS_TO_SCALE_FOR_TEST = list(set(test_dataset.columns) & set(NUMERIC_COLS_TO_SCALE))
-{{ test_dataset }}[NUMERIC_COLS_TO_SCALE_FOR_TEST] = np.log1p({{ test_dataset }}[NUMERIC_COLS_TO_SCALE_FOR_TEST])
+{{ test_dataset }}[NUMERIC_COLS_TO_SCALE_FOR_TEST] = np.log1p({{ test_dataset }}[NUMERIC_COLS_TO_SCALE_FOR_TEST]).replace([np.inf, -np.inf], np.nan).fillna({{ test_dataset }}[NUMERIC_COLS_TO_SCALE_FOR_TEST].mean())
+

--- a/sapientml_core/templates/preprocessing_templates/log_predict.py.jinja
+++ b/sapientml_core/templates/preprocessing_templates/log_predict.py.jinja
@@ -2,4 +2,5 @@ import numpy as np
 
 NUMERIC_COLS_TO_SCALE = {{ columns }}
 NUMERIC_COLS_TO_SCALE_FOR_TEST = list(set(test_dataset.columns) & set(NUMERIC_COLS_TO_SCALE))
-{{ test_dataset }}[NUMERIC_COLS_TO_SCALE_FOR_TEST] = np.log1p({{ test_dataset }}[NUMERIC_COLS_TO_SCALE_FOR_TEST])
+{{ test_dataset }}[NUMERIC_COLS_TO_SCALE_FOR_TEST] = np.log1p({{ test_dataset }}[NUMERIC_COLS_TO_SCALE_FOR_TEST]).replace([np.inf, -np.inf], np.nan).fillna({{ test_dataset }}[NUMERIC_COLS_TO_SCALE_FOR_TEST].mean())
+

--- a/sapientml_core/templates/preprocessing_templates/log_train.py.jinja
+++ b/sapientml_core/templates/preprocessing_templates/log_train.py.jinja
@@ -1,4 +1,5 @@
 import numpy as np
 
 NUMERIC_COLS_TO_SCALE = {{ columns }}
-{{ train_dataset }}[NUMERIC_COLS_TO_SCALE] = np.log1p({{ train_dataset }}[NUMERIC_COLS_TO_SCALE])
+{{ train_dataset }}[NUMERIC_COLS_TO_SCALE] = np.log1p({{ train_dataset }}[NUMERIC_COLS_TO_SCALE]).replace([np.inf, -np.inf], np.nan).fillna({{ train_dataset }}[NUMERIC_COLS_TO_SCALE].mean())
+


### PR DESCRIPTION
@kimusaku san ,

- For some datasets, during model predictions, all candidate pipelines failed with the following exception:
  
         ValueError: Input X contains infinity or a value too large for dtype('float64')    
- As a result, no scores were generated, and the following exception occurred:
        
          RuntimeError: All candidate scripts failed. Final script is not saved.
         

<details> <summary><b>Issue</b></summary>

   - After applying Log transformation, the candidate pipelines were raising a `ValueError` when input data contained infinite (np.inf or -np.inf) or excessively large values during model prediction
   - While certain models like `XGBClassifier `and other gradient boosting models can handle these issues internally.
   - But other models such as` MLPClassifier`,` RandomForestClassifier`, and similar algorithms raise errors during prediction when they encounter such values.
</details>

<details> <summary><b>Fix</b></summary>
 To prevent these errors, 
 
 -  We added a step to replace any` np.inf `or` -np.inf` values in the dataset with `NaN`. 
 -  After replacing the infinite values, we filled any resulting `NaN` values with the mean of the respective columns, ensuring that the data remains compatible with all classifiers
 - If the dataset contains no` np.inf` values after the `log transformation`, this replacement step will not have any effect.
 </details>
 </details> <details> <summary><b>Changes</b></summary>

  Updated the following preprocessing templates to handle infinity and large values:
     
       core/sapientml_core/templates/preprocessing_templates/log.py.jinja
       core/sapientml_core/templates/preprocessing_templates/log_predict.py.jinja
       core/sapientml_core/templates/preprocessing_templates/log_train.py.jinja
       
</details>

<details> <summary><b>Impact</b></summary>

-  This fix ensures that models like `MLPClassifier,` `RandomForestClassifier`, and other models that cannot handle `infinity `or large values will no longer throw `ValueError` during prediction.
-  It improves the robustness and compatibility of the preprocessing  pipeline for different classifiers, ensuring consistent behavior across all models.
</details> 

Thankyou