### PR TITLE
fix: narrow MLP alpha search range and replace deprecated suggest_loguniform

### DIFF
--- a/sapientml_core/templates/model_templates/hyperparameters.py.jinja
+++ b/sapientml_core/templates/model_templates/hyperparameters.py.jinja
@@ -55,33 +55,33 @@
             params['min_samples_leaf'] = trial.suggest_int('min_samples_leaf', 1, 32, log=True) # 1
             params['max_features'] = trial.suggest_categorical('max_features', ['sqrt','log2', None]) # None 
 {% elif (model_name == "SVC") %}
-            params['C'] = trial.suggest_loguniform('C', 1e-5, 1e2) # 1 
+            params['C'] = trial.suggest_float('C', 1e-5, 1e2, log=True) # 1 
 {#            params['gamma'] = trial.suggest_float('gamma', 1e-8, 1.0, log=True) # scale  #}
             params['class_weight'] = trial.suggest_categorical('class_weight', ['balanced', None]) # None 
 {% elif (model_name == "SVR") %}
-            params['C'] = trial.suggest_loguniform('C', 1e-5, 1e2) # 1 
+            params['C'] = trial.suggest_float('C', 1e-5, 1e2, log=True) # 1 
 {#            params['gamma'] = trial.suggest_float('gamma', 1e-8, 1.0, log=True) # scale  #}
 {% elif model_name == "LinearSVC" %}
             params['penalty'] =  trial.suggest_categorical('penalty', ['l1', 'l2']) # l2 
             params['loss'] =  trial.suggest_categorical('loss', ['hinge', 'squared_hinge']) # squared_hinge 
-            params['C'] = trial.suggest_loguniform('C', 1e-5, 1e2) # 1 
+            params['C'] = trial.suggest_float('C', 1e-5, 1e2, log=True) # 1 
             params['intercept_scaling'] = trial.suggest_float('intercept_scaling', 0.3, 2) # 1  
             params['class_weight'] = trial.suggest_categorical('class_weight', ['balanced', None]) # None 
 {% elif model_name == "LogisticRegression" %}
             #params['penalty'] =  trial.suggest_categorical('penalty', ['l1', 'l2', 'elasticnet']) # l2 
-            params['C'] = trial.suggest_loguniform('C', 1e-5, 1e2) # 1 
+            params['C'] = trial.suggest_float('C', 1e-5, 1e2, log=True) # 1 
             #params['solver'] = trial.suggest_categorical('solver', ['lbfgs','saga']) # lbfgs 
             params['class_weight'] = trial.suggest_categorical('class_weight', ['balanced', None]) # None 
 {% elif model_name == "SGDClassifier" %}
             params['loss'] =  trial.suggest_categorical('loss', ['hinge', 'log', 'modified_huber', 'squared_hinge', 'perceptron', 'squared_error', 'squared_loss', 'huber', 'epsilon_insensitive', 'squared_epsilon_insensitive']) # hinge
             params['penalty'] =  trial.suggest_categorical('penalty', ['l1', 'l2', 'elasticnet']) # l2 
-            params['alpha'] = trial.suggest_loguniform('alpha', 1e-6, 1.0) # 0.0001 
+            params['alpha'] = trial.suggest_float('alpha', 1e-6, 1.0, log=True) # 0.0001 
             #params['early_stopping'] =  trial.suggest_categorical('early_stopping', [True]) # False 
             params['class_weight'] = trial.suggest_categorical('class_weight', ['balanced', None]) # None 
 {% elif model_name == "MLPClassifier" or model_name == "MLPRegressor" %}
             params['activation'] =  trial.suggest_categorical('activation', ['identity', 'logistic', 'tanh', 'relu']) # relu 
             params['solver'] = trial.suggest_categorical('solver', ['lbfgs','sgd', 'adam']) # adam 
-            params['alpha'] = trial.suggest_loguniform('alpha', 1e-6, 1.0) # 0.0001 
+            params['alpha'] = trial.suggest_float('alpha', 1e-6, 1e-3, log=True) # 0.0001 
 {#% elif model_name == "MultinomialNB" %#}
 {#% elif model_name == "GaussianNB" %#}
 {#% elif model_name == "BernoulliNB" %#}
@@ -114,7 +114,7 @@
 {#            params['max_depth'] =  trial.suggest_int('max_depth', 1, 11, 1) # None  #}
             params['min_samples_leaf'] = trial.suggest_int('min_samples_leaf', 1, 32, log=True) # 1
             params['max_features'] = trial.suggest_categorical('max_features', ['sqrt','log2', None]) # None 
-            params['alpha'] = trial.suggest_loguniform('alpha', 1e-6, 1.0) # 0.9, only if loss='huber' or loss='quantile'
+            params['alpha'] = trial.suggest_float('alpha', 1e-6, 1.0, log=True) # 0.9, only if loss='huber' or loss='quantile'
 {% elif model_name == "AdaBoostRegressor" %}
             params['n_estimators'] =  trial.suggest_int('n_estimators', 10, 1000, log=True) # 100
             params['loss'] =  trial.suggest_categorical('loss', ['linear', 'square', 'exponential']) # linear 
@@ -124,14 +124,14 @@
             params['min_samples_leaf'] = trial.suggest_int('min_samples_leaf', 1, 32, log=True) # 1
             params['max_features'] = trial.suggest_categorical('max_features', ['sqrt','log2', None]) # None 
 {% elif model_name == "LinearSVR" %}
-            params['C'] = trial.suggest_loguniform('C', 1e-5, 1e2) # 1 
+            params['C'] = trial.suggest_float('C', 1e-5, 1e2, log=True) # 1 
             params['loss'] =  trial.suggest_categorical('loss', ['epsilon_insensitive', 'squared_epsilon_insensitive']) # epsilon_insensitive
             params['intercept_scaling'] = trial.suggest_float('intercept_scaling', 0.3, 2, log=True) # 1  
 {#% elif model_name == "LinearRegression" %#}
 {% elif model_name == "Lasso" %}
-            params['alpha'] = trial.suggest_loguniform('alpha', 1e-5, 10.0) # 1 
+            params['alpha'] = trial.suggest_float('alpha', 1e-5, 10.0, log=True) # 1 
 {% elif model_name == "SGDRegressor" %}
             params['loss'] =  trial.suggest_categorical('loss', ['squared_error', 'squared_loss', 'huber', 'epsilon_insensitive', 'squared_epsilon_insensitive']) # squared_loss  
             params['penalty'] =  trial.suggest_categorical('penalty', ['l1', 'l2', 'elasticnet']) # l2 
-            params['alpha'] = trial.suggest_loguniform('alpha', 1e-6, 1.0) # 0.0001 
+            params['alpha'] = trial.suggest_float('alpha', 1e-6, 1.0, log=True) # 0.0001 
 {% endif %}

--- a/tests/sapientml/test_hyperparameters_template.py
+++ b/tests/sapientml/test_hyperparameters_template.py
@@ -1,0 +1,156 @@
+# Copyright 2023-2024 The SapientML Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Regression tests for sapientml/core#63.
+
+Verify that:
+1. hyperparameters.py.jinja renders ``suggest_float('alpha', 1e-6, 1e-3, log=True)``
+   for MLPClassifier and MLPRegressor — the old upper bound of 1.0 caused
+   "ValueError: Solver produced non-finite parameter weights".
+2. No model in the template uses the deprecated ``suggest_loguniform()`` API
+   (removed in optuna v4+).
+3. An optuna study using the fixed alpha range on synthetic data completes all
+   trials without ValueError for both MLPClassifier and MLPRegressor.
+"""
+
+from pathlib import Path
+
+import numpy as np
+import optuna
+import pandas as pd
+import pytest
+from jinja2 import Environment, FileSystemLoader
+from sklearn.neural_network import MLPClassifier, MLPRegressor
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_TEMPLATES_DIR = Path(__file__).parent.parent.parent / "sapientml_core" / "templates"
+
+# Every model name that appears in hyperparameters.py.jinja
+_ALL_MODEL_NAMES = [
+    "AdaBoostClassifier",
+    "AdaBoostRegressor",
+    "BernoulliNB",
+    "CatBoostClassifier",
+    "CatBoostRegressor",
+    "DecisionTreeClassifier",
+    "DecisionTreeRegressor",
+    "ExtraTreesClassifier",
+    "ExtraTreesRegressor",
+    "GaussianNB",
+    "GradientBoostingClassifier",
+    "GradientBoostingRegressor",
+    "Lasso",
+    "LGBMClassifier",
+    "LGBMRegressor",
+    "LinearRegression",
+    "LinearSVC",
+    "LinearSVR",
+    "LogisticRegression",
+    "MLPClassifier",
+    "MLPRegressor",
+    "MultinomialNB",
+    "RandomForestClassifier",
+    "RandomForestRegressor",
+    "SGDClassifier",
+    "SGDRegressor",
+    "SVC",
+    "SVR",
+    "XGBClassifier",
+    "XGBRegressor",
+]
+
+
+def _render(model_name: str) -> str:
+    env = Environment(loader=FileSystemLoader(str(_TEMPLATES_DIR)), trim_blocks=True)
+    return env.get_template("model_templates/hyperparameters.py.jinja").render(model_name=model_name)
+
+
+# ---------------------------------------------------------------------------
+# Template content — MLP alpha search range (issue #63)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("model_name", ["MLPClassifier", "MLPRegressor"])
+def test_misc_hyperparameters_mlp_alpha_uses_narrowed_upper_bound(model_name):
+    """Fix #63: alpha must be sampled from [1e-6, 1e-3], not [1e-6, 1.0].
+
+    An upper bound of 1.0 caused optuna to sample large alpha values that
+    drove the solver to produce non-finite weights.
+    """
+    code = _render(model_name)
+    assert "suggest_float('alpha', 1e-6, 1e-3, log=True)" in code
+
+
+# ---------------------------------------------------------------------------
+# Template content — deprecated suggest_loguniform (issue #63)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("model_name", _ALL_MODEL_NAMES)
+def test_misc_hyperparameters_no_suggest_loguniform_any_model(model_name):
+    """suggest_loguniform() was removed in optuna v4; no model may use it."""
+    assert "suggest_loguniform" not in _render(model_name)
+
+
+# ---------------------------------------------------------------------------
+# Integration — optuna study with fixed alpha range must not raise ValueError
+# ---------------------------------------------------------------------------
+
+
+def _synthetic_dataset(task_type: str):
+    rng = np.random.default_rng(0)
+    X = pd.DataFrame(rng.standard_normal((120, 8)))
+    y = pd.Series(rng.integers(0, 2, 120).astype(int) if task_type == "classification" else rng.standard_normal(120))
+    return X.iloc[:90], X.iloc[90:], y.iloc[:90], y.iloc[90:]
+
+
+@pytest.mark.parametrize(
+    "model_cls,task_type",
+    [
+        (MLPRegressor, "regression"),
+        (MLPClassifier, "classification"),
+    ],
+)
+def test_misc_mlp_tuning_fixed_alpha_range_completes_without_error(model_cls, task_type):
+    """Fix #63: all optuna trials with alpha in [1e-6, 1e-3] must complete.
+
+    Mirrors what the rendered hyperparameter-tuning script does at runtime:
+    an objective that calls ``suggest_float('alpha', 1e-6, 1e-3, log=True)``
+    and fits the MLP must never raise ValueError.
+    """
+    X_train, X_test, y_train, y_test = _synthetic_dataset(task_type)
+
+    def objective(trial):
+        params = {
+            "activation": trial.suggest_categorical("activation", ["identity", "logistic", "tanh", "relu"]),
+            "solver": trial.suggest_categorical("solver", ["lbfgs", "sgd", "adam"]),
+            "alpha": trial.suggest_float("alpha", 1e-6, 1e-3, log=True),  # fixed range from PR #119
+        }
+        model = model_cls(random_state=0, max_iter=500, **params)
+        model.fit(X_train, y_train)
+        return model.score(X_test, y_test)
+
+    optuna.logging.set_verbosity(optuna.logging.WARNING)
+    study = optuna.create_study(
+        direction="maximize",
+        sampler=optuna.samplers.TPESampler(seed=0),
+    )
+    study.optimize(objective, n_trials=10, timeout=60)
+
+    assert len(study.trials) > 0, "No trials ran"
+    failed = [t for t in study.trials if t.state != optuna.trial.TrialState.COMPLETE]
+    assert not failed, f"{len(failed)} trial(s) did not complete: {[t.state for t in failed]}"


### PR DESCRIPTION
## Summary

Fixes #63

## Root Cause

During hyperparameter tuning with `MLPRegressor` (or `MLPClassifier`), Optuna's search space for `alpha` (L2 regularization coefficient) was `[1e-6, 1.0]`. When a large alpha value (close to 1.0) is sampled, the solver weights diverge, causing:

```
ValueError: Solver produced non-finite parameter weights. The input data may contain large values and need to be preprocessed.
```

## Fix

1. **Narrow MLP `alpha` upper bound**: `1.0` → `1e-3`  
   The default value is `0.0001` (1e-4), so the range `[1e-6, 1e-3]` is a reasonable neighbourhood around the default.

2. **Replace deprecated `suggest_loguniform`**: All `trial.suggest_loguniform(name, low, high)` calls → `trial.suggest_float(name, low, high, log=True)`  
   `suggest_loguniform` has been deprecated since optuna v3.0.0 and will be removed in v6.0.0 (currently generates `FutureWarning` on optuna 4.x).

## Changed File

- `sapientml_core/templates/model_templates/hyperparameters.py.jinja`